### PR TITLE
android15-16kb-page-size

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,6 +29,11 @@ LOCAL_CFLAGS += -DSQLITE_ENABLE_RTREE
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_PAGE_SIZE=1024
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_CACHE_SIZE=2000
 
+# 08/08/2024 Android 15 : Add Page Size 16Kb support
+# https://developer.android.com/guide/practices/page-sizes
+# https://source.android.com/docs/core/architecture/16kb-page-size/16kb
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+
 LOCAL_SRC_FILES := ../native/sqlc_all.c
 
 include $(BUILD_SHARED_LIBRARY)

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,7 @@
 #APP_ABI := all
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+#APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
 # For future consideration (needs testing):
 #APP_ABI += mips mips64
+APP_PLATFORM := android-22
 


### PR DESCRIPTION
Android 15 : Add Page Size 16 Kb support
https://developer.android.com/guide/practices/page-sizes https://source.android.com/docs/core/architecture/16kb-page-size/16kb