### PR TITLE
Add Android 15 Support pagesize 16Kb support : Test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,7 +11,7 @@ regen:
 # NOTE: adding v (verbose) flag for the beginning stage:
 ndkbuild:
 	rm -rf lib libs
-	ndk-build
+	/cygdrive/c/Users/alex/AppData/Local/Android/Sdk/ndk/26.1.10909125/ndk-build.cmd
 	zip sqlite-native-driver-libs.zip libs/*/*
 	mv libs lib
 	jar cf sqlite-native-driver.jar lib

--- a/Makefile
+++ b/Makefile
@@ -11,11 +11,12 @@ regen:
 # NOTE: adding v (verbose) flag for the beginning stage:
 ndkbuild:
 	rm -rf lib libs
-	/cygdrive/c/Users/alex/AppData/Local/Android/Sdk/ndk/26.1.10909125/ndk-build.cmd
+	# 29/08/2024 Android 15 : Add Page Size 16Kb support
+	# ndk-build
+	ndk-build.cmd
 	zip sqlite-native-driver-libs.zip libs/*/*
 	mv libs lib
 	jar cf sqlite-native-driver.jar lib
 
 clean:
 	rm -rf obj lib libs sqlite-native-driver.jar *.zip
-

--- a/README.md
+++ b/README.md
@@ -1,3 +1,12 @@
+# WARNING TEST PLUGIN
+
+This plugin is forked from https://github.com/liteglue/Android-sqlite-native-driver, and only provided to test the compilation of new Libs for Android 15 16Kb Page Size.
+TODO:
+- Test libraries
+- Replace hardcoded path (ex: ndk-build in Mainfile)
+- Test with https://github.com/hooliapps/cordova-sqlite-legacy-build-support / https://github.com/brodycj/cordova-sqlite-legacy-build-support / 
+- Commit in the original package
+
 # Android sqlite native driver
 
 Provides Android NDK build of sqlite3 (<http://sqlite.org/>, public domain) with a low-level JNI interface accessible from a single (singleton) single `SQLiteNative` class.

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,9 +29,10 @@ LOCAL_CFLAGS += -DSQLITE_ENABLE_RTREE
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_PAGE_SIZE=1024
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_CACHE_SIZE=2000
 
-# 08/08/2024 Android 15 : Add Page Size 16Kb support
+# 29/08/2024 Android 15 : Add Page Size 16Kb support
 # https://developer.android.com/guide/practices/page-sizes
 # https://source.android.com/docs/core/architecture/16kb-page-size/16kb
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
 
 LOCAL_SRC_FILES := ../native/sqlc_all.c

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -29,6 +29,11 @@ LOCAL_CFLAGS += -DSQLITE_ENABLE_RTREE
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_PAGE_SIZE=1024
 LOCAL_CFLAGS += -DSQLITE_DEFAULT_CACHE_SIZE=2000
 
+# 08/08/2024 Android 15 : Add Page Size 16Kb support
+# https://developer.android.com/guide/practices/page-sizes
+# https://source.android.com/docs/core/architecture/16kb-page-size/16kb
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+
 LOCAL_SRC_FILES := ../native/sqlc_all.c
 
 include $(BUILD_SHARED_LIBRARY)

--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -32,7 +32,6 @@ LOCAL_CFLAGS += -DSQLITE_DEFAULT_CACHE_SIZE=2000
 # 29/08/2024 Android 15 : Add Page Size 16Kb support
 # https://developer.android.com/guide/practices/page-sizes
 # https://source.android.com/docs/core/architecture/16kb-page-size/16kb
-APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
 
 LOCAL_SRC_FILES := ../native/sqlc_all.c

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -4,3 +4,6 @@
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
 # For future consideration (needs testing):
 #APP_ABI += mips mips64
+
+# 03/09/2024 Android 15 : Add Page Size 16Kb support
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,7 +1,6 @@
 #APP_ABI := all
-#APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+# 29/08/2024 Android 15 : Add Page Size 16Kb support
+# APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
 APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
 # For future consideration (needs testing):
 #APP_ABI += mips mips64
-APP_PLATFORM := android-22
-

--- a/jni/Application.mk
+++ b/jni/Application.mk
@@ -1,5 +1,7 @@
 #APP_ABI := all
-APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+#APP_ABI := armeabi armeabi-v7a x86 x86_64 arm64-v8a
+APP_ABI := armeabi-v7a x86 x86_64 arm64-v8a
 # For future consideration (needs testing):
 #APP_ABI += mips mips64
+APP_PLATFORM := android-22
 

--- a/notes.txt
+++ b/notes.txt
@@ -1,0 +1,6 @@
+C:\Users\alex\Documents\GitHub\Android-sqlite-native-driver
+Edit Android.mk
+Add LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+cd C:\Users\alex\Documents\GitHub\Android-sqlite-native-driver with cygwin
+make init
+make

--- a/notes.txt
+++ b/notes.txt
@@ -1,3 +1,5 @@
+THIS IS A TEST !
+
 Notes to compile on Windows with Cygwin
 
 Edit Android.mk

--- a/notes.txt
+++ b/notes.txt
@@ -1,12 +1,14 @@
 Notes to compile on Windows with Cygwin
 
 Edit Android.mk
+LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
+
+Edit Application.mk
 APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
-Add LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384,-z,common-page-size=16384"
 
 Open cygwin
 	cd /cygdrive/c/Users/alex/Documents/GitHub/Android-sqlite-native-driver
-	export PATH=$PATH:/cygdrive/c/Users/alex/AppData/Local/Android/Sdk/ndk/26.1.10909125/
+	export PATH=$PATH:/cygdrive/c/Users/alex/AppData/Local/Android/Sdk/ndk/27.0.12077973/
 	export PATH=$PATH:export PATH=$PATH:/cygdrive/c/Program\ Files/Java/jdk-18.0.2/bin/
 	source ~/.bashrc
 	make init

--- a/notes.txt
+++ b/notes.txt
@@ -1,10 +1,16 @@
-C:\Users\alex\Documents\GitHub\Android-sqlite-native-driver
+Notes to compile on Windows with Cygwin
+
 Edit Android.mk
+APP_SUPPORT_FLEXIBLE_PAGE_SIZES := true
 Add LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384,-z,common-page-size=16384"
+
 Open cygwin
 	cd /cygdrive/c/Users/alex/Documents/GitHub/Android-sqlite-native-driver
+	export PATH=$PATH:/cygdrive/c/Users/alex/AppData/Local/Android/Sdk/ndk/26.1.10909125/
+	export PATH=$PATH:export PATH=$PATH:/cygdrive/c/Program\ Files/Java/jdk-18.0.2/bin/
+	source ~/.bashrc
 	make init
 	make
-
-
-* arm64-v8a non recompilé
+	
+Remarks:
+- armeabi platform is obsolete

--- a/notes.txt
+++ b/notes.txt
@@ -1,6 +1,10 @@
 C:\Users\alex\Documents\GitHub\Android-sqlite-native-driver
 Edit Android.mk
-Add LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384"
-cd C:\Users\alex\Documents\GitHub\Android-sqlite-native-driver with cygwin
-make init
-make
+Add LOCAL_LDFLAGS += "-Wl,-z,max-page-size=16384,-z,common-page-size=16384"
+Open cygwin
+	cd /cygdrive/c/Users/alex/Documents/GitHub/Android-sqlite-native-driver
+	make init
+	make
+
+
+* arm64-v8a non recompilé


### PR DESCRIPTION
This is a test change.

I added Android 15 Support pagesize 16Kb support, by recompiling libraries with cygwin.

To be checked before !

I tested on:

Pixel 8 with Android 15 Beta QPR1 + Pagesize 4Kb mode
Pixel 8 with Android 15 Beta QPR1 + Pagesize 16Kb mode
Amazon Fire tablet
Retroid 3+
Robotest:
Nexus 5X, Virtuel, API 26
Galaxy Tab A8, API 34
Pixel 5, API 30
Galaxy S20, API 29
Medium Phone, 6.4in/16cm (Arm), Virtual, API 34